### PR TITLE
fix pressable footer button when already selected

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,12 +8,12 @@ import { usePathname } from 'expo-router';
 
 export default function Footer() {
   const router = useRouter();
-  const [selected, setSelected] = useState('/home');
+  const [selected, setSelected] = useState('home');
   const pathname = usePathname();
 
   useEffect(() => {
     console.log(pathname);
-    setSelected(pathname);
+    setSelected(pathname.replace('/', ''));
   }, [pathname]);
 
   const handlePress = (screen: string) => {
@@ -23,14 +23,14 @@ export default function Footer() {
 
   return (
     <View style={styles.footer}>
-      <TouchableOpacity onPress={() => handlePress('/home')}>
-        <Garden color={selected === '/home' ? '#ECFFEB' : '#B0C5AF'} />
+      <TouchableOpacity onPress={() => handlePress('home')} disabled={selected === 'home'}>
+        <Garden color={selected === 'home' ? '#ECFFEB' : '#B0C5AF'} />
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => handlePress('/log')}>
-        <Log color={selected === '/log' ? '#ECFFEB' : '#B0C5AF'} />
+      <TouchableOpacity onPress={() => handlePress('log')} disabled={selected === 'log'}>
+        <Log color={selected === 'log' ? '#ECFFEB' : '#B0C5AF'} />
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => handlePress('/group')}>
-        <Group color={selected === '/group' ? '#ECFFEB' : '#B0C5AF'} />
+      <TouchableOpacity onPress={() => handlePress('group')} disabled={selected === 'group'}>
+        <Group color={selected === 'group' ? '#ECFFEB' : '#B0C5AF'} />
       </TouchableOpacity>
     </View>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-native-gesture-handler": "~2.20.2",
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
-        "react-native-screens": "^4.0.0",
+        "react-native-screens": "^4.1.0",
         "react-native-svg": "15.8.0",
         "react-native-uuid": "^2.0.2",
         "react-native-web": "~0.19.10",
@@ -17562,9 +17562,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.0.0.tgz",
-      "integrity": "sha512-QGQ8+d90chOZ9JwA2K01nFzrGCTMNjsiAKJGPUXcLEiIF77/VSjLjQE9ZluMtkva0gzGI9tb/yxETkJnkw1iag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.1.0.tgz",
+      "integrity": "sha512-tCBwe7fRMpoi/nIgZxE86N8b2SH8d5PlfGaQO8lgqlXqIyvwqm3u1HJCaA0tsacPyzhW7vVtRfQyq9e1j0S2gA==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-native-gesture-handler": "~2.20.2",
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
-        "react-native-screens": "^4.1.0",
+        "react-native-screens": "^4.0.0",
         "react-native-svg": "15.8.0",
         "react-native-uuid": "^2.0.2",
         "react-native-web": "~0.19.10",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-gesture-handler": "~2.20.2",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "^4.1.0",
+    "react-native-screens": "^4.0.0",
     "react-native-svg": "15.8.0",
     "react-native-uuid": "^2.0.2",
     "react-native-web": "~0.19.10",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-gesture-handler": "~2.20.2",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "^4.0.0",
+    "react-native-screens": "^4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-uuid": "^2.0.2",
     "react-native-web": "~0.19.10",


### PR DESCRIPTION
This pull request includes updates to the `Footer` component in the `components/Footer.tsx` file to improve navigation handling by removing the leading slash from pathnames and disabling buttons for the currently selected screen.

Navigation handling improvements:

* Changed the initial state of `selected` from `'/home'` to `'home'` and updated the `useEffect` hook to remove the leading slash from `pathname` before setting the `selected` state.
* Updated the `TouchableOpacity` components to remove the leading slash from the screen names in the `handlePress` function calls and added a `disabled` attribute to disable the button for the currently selected screen.